### PR TITLE
fix: all heights using NAVBAR_HEIGHT variable

### DIFF
--- a/frontend/app/(authenticated)/events/[id]/page.tsx
+++ b/frontend/app/(authenticated)/events/[id]/page.tsx
@@ -137,6 +137,7 @@ const Page = ({ params }: { params: { id: string } }) => {
         </div>
       </div>
       {isViewAnnotation && (
+        // h-[calc(100vh_-_84px)] min-h-[calc(100vh_-_84px)] max-h-[calc(100vh_-_84px)]
         <div
           className={
             `sticky top-0 min-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] max-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] ` +

--- a/frontend/app/landing.tsx
+++ b/frontend/app/landing.tsx
@@ -22,6 +22,7 @@ const Landing = () => {
     <div className="relative w-full h-full overflow-y-auto">
       <div className="flex flex-col bg-muted w-full h-fit">
         <div
+          // h-[calc(100vh_-_84px)] min-h-[calc(100vh_-_84px)] max-h-[calc(100vh_-_84px)]
           className={`flex flex-col w-full items-center justify-center px-12 md:px-0 py-8 gap-y-8 h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] min-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] max-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)]`}
         >
           <h1 className="flex max-w-xl text-center text-4xl sm:text-5xl md:text-7xl font-bold text-primary-800 animate-fade-up">

--- a/frontend/components/layout/app-layout.tsx
+++ b/frontend/components/layout/app-layout.tsx
@@ -51,6 +51,7 @@ const AppLayout = ({ children }: { children: ReactNode }) => {
       <Navbar />
       <MobileNavbar />
       <main
+        // h-[calc(100vh_-_84px)] min-h-[calc(100vh_-_84px)] max-h-[calc(100vh_-_84px)]
         className={`flex w-full h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] min-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)] max-h-[calc(100vh_-_${NAVBAR_HEIGHT}px)]`}
       >
         <Suspense

--- a/frontend/components/navigation/mobile/mobile-navbar.tsx
+++ b/frontend/components/navigation/mobile/mobile-navbar.tsx
@@ -17,6 +17,7 @@ function MobileNavbar() {
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
 
   return (
+    // min-h-[84px] max-h-[84px]
     <header
       className={`md:hidden sticky top-0 z-50 w-full border-border backdrop-blur-lg bg-background/60 border-b-[1px] min-h-[${NAVBAR_HEIGHT}px] max-h-[${NAVBAR_HEIGHT}px`}
     >

--- a/frontend/components/navigation/mobile/mobile-navbar.tsx
+++ b/frontend/components/navigation/mobile/mobile-navbar.tsx
@@ -19,7 +19,7 @@ function MobileNavbar() {
   return (
     // min-h-[84px] max-h-[84px]
     <header
-      className={`md:hidden sticky top-0 z-50 w-full border-border backdrop-blur-lg bg-background/60 border-b-[1px] min-h-[${NAVBAR_HEIGHT}px] max-h-[${NAVBAR_HEIGHT}px`}
+      className={`md:hidden sticky top-0 z-50 w-full border-border backdrop-blur-lg bg-background/60 border-b-[1px] min-h-[${NAVBAR_HEIGHT}px] max-h-[${NAVBAR_HEIGHT}px]`}
     >
       <div className="w-full flex items-center justify-between px-8 py-4">
         <div className="flex items-center">

--- a/frontend/components/navigation/navbar.tsx
+++ b/frontend/components/navigation/navbar.tsx
@@ -22,6 +22,7 @@ function Navbar() {
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
 
   return (
+    // min-h-[84px] max-h-[84px]
     <header
       className={`hidden md:flex sticky top-0 z-50 w-full ${isLoggedIn ? "bg-background/60 border-border" : "bg-muted/60 border-muted"} backdrop-blur-lg border-b-[1px] min-h-[${NAVBAR_HEIGHT}px] max-h-[${NAVBAR_HEIGHT}px]`}
     >


### PR DESCRIPTION
reminder: you CANNOT just sub in a variable into tailwindcss classes. Tailwind works by exact matching classes to emit CSS, so if tailwind just sees `h-[calc(100vh_-_${NAVBAR_HEIGHT}px)]` it is not going to work.